### PR TITLE
Add post descriptions

### DIFF
--- a/content/vault/FirstPodcastEpisode.md
+++ b/content/vault/FirstPodcastEpisode.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-07-06
 title: First podcast episode!
+description: Welcome to the first episode of the unspent.space podcast.
 author: crispy
 tags:
   - podcast

--- a/content/vault/HackBsPodcast.md
+++ b/content/vault/HackBsPodcast.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-08-01
 title: hack.bs - Hackerspace in Italy!
+description: Daniela and Alekos describe their journey to founding hackbs, a bitcoin-centric hackerspace in Brescia, Italy.
 author: crispy
 tags:
   - podcast

--- a/content/vault/SatoshiPlace.md
+++ b/content/vault/SatoshiPlace.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-07-10
 title: Satoshi's Place, UK
+description: Crispy chats with Adam, the owner of Satoshi's Place, a bitcoin hub located in Bury, UK.
 author: crispy
 tags:
   - podcast

--- a/content/vault/Welcome.md
+++ b/content/vault/Welcome.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-07-02
 title: Welcome to unspent.space
+description: Welcome to the unspent.space site. Whether you're trying to start your own space or joining others, this community will help you join the dots.
 author: crispy
 tags:
   - welcome

--- a/content/vault/What is an unspent space?!.md
+++ b/content/vault/What is an unspent space?!.md
@@ -1,6 +1,7 @@
 ---
 date: 2023-07-19
 title: What is an unspent space?!
+description: What is this all about??
 author: Crispy
 tags:
   - bitcoin

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -21,6 +21,7 @@ exports.createSchemaCustomization = ({ actions }) => {
     type Frontmatter {
       title: String
       author: String
+      description: String
       date: Date
       tags: [String]
       category: String

--- a/src/components/ListNote.tsx
+++ b/src/components/ListNote.tsx
@@ -14,7 +14,7 @@ export default function ListNote({ edges }) {
             <h2 className="underline my-2">{edge.node.fields.title}</h2>
           </Link>
           <p className="mb-2 text-lightgrey">
-            {edge.node.excerpt || edge.node.frontmatter.description}
+            {edge.node.frontmatter.description || edge.node.excerpt}
           </p>
           {/* <small className="bg-dimgrey text-yellow text-xs tracking-normal uppercase rounded-lg px-2 py-1 my-2">
             {edge.node.fields.stage}

--- a/src/utils/fragments.js
+++ b/src/utils/fragments.js
@@ -4,7 +4,7 @@ export const postFragment = graphql`
   fragment post on Mdx {
     id
     body
-    excerpt(pruneLength: 300)
+    excerpt(pruneLength: 150)
     fields {
       date
       title
@@ -18,6 +18,7 @@ export const postFragment = graphql`
       date
       tags
       title
+      description
       author
       socialImage {
         publicURL
@@ -43,9 +44,10 @@ export const postFragment = graphql`
       tagSlugs
       stage
     }
-    excerpt(pruneLength: 300)
+    excerpt(pruneLength: 150)
     frontmatter {
       title
+      description
       date
       author
       category


### PR DESCRIPTION
There is too much text on the homepage IMO.

I had a go at adding a `description` field to the Frontmatter.

I actually have no idea what I am doing so this is new and fun (what do you call this type of website?), not confident I have added this field correctly.

I also shortened the default excerpt length to 150 chars.