### PR TITLE
Style changes to blockheight header

### DIFF
--- a/config.js
+++ b/config.js
@@ -26,10 +26,6 @@ module.exports = {
       label: "contribute",
       path: "/contribute/",
     },
-    {
-      label: "topics",
-      path: "/topics/",
-    },
   ],
   FOOTER: [
     {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,8 +16,7 @@ export default function Header() {
   return (
     <header>
       <Container>
-        <p className="bg-darkgrey rounded-md text-center py-1 mt-5 text-md animate-pulse">block height: {data}</p>
-        <nav className="flex justify-between py-6 md:py-10">
+        <nav className="flex justify-between py-3 md:py-5 mt-5">
           <Link to="/" className="text-whitegrey">
             unspent<span className="text-yellow text-4xl">.</span>space
           </Link>
@@ -47,6 +46,7 @@ export default function Header() {
             <MdOpenInNew />
           </Link>
         </nav>
+        <p className="bg-darkgrey rounded-md text-center py-1 text-md mb-5">block height - <b className="animate-pulse">{data}</b></p>
       </Container>
     </header>
   );


### PR DESCRIPTION
Some opinions on header styling,
changed so only the number pulses

With this commit:
![image](https://github.com/unspentspace/unspent.space/assets/24557779/793b4d7b-c17f-449f-9e0d-fc7c0d0d519e)



before commit
![image](https://github.com/unspentspace/unspent.space/assets/24557779/5317d8fa-0b01-4baa-b7b6-a7d787df467a)
